### PR TITLE
feat: Added Support for Self-Hosted Firecrawl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,3 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
-report.md

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+report.md

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ npm install
 
 ```bash
 FIRECRAWL_KEY="your_firecrawl_key"
-# If you want to use your localhost firecrawl, add the following below:
-FIRECRAWL_BASE_URL="http://localhost:3002"
+# If you want to use your self-hosted Firecrawl, add the following below:
+# FIRECRAWL_BASE_URL="http://localhost:3002"
 
 OPENAI_KEY="your_openai_key"
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ npm install
 
 ```bash
 FIRECRAWL_KEY="your_firecrawl_key"
+# If you want to use your localhost firecrawl, add the following below:
+FIRECRAWL_BASE_URL="http://localhost:3002"
+
 OPENAI_KEY="your_openai_key"
 ```
 

--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -15,9 +15,28 @@ type ResearchResult = {
 // increase this if you have higher API rate limits
 const ConcurrencyLimit = 2;
 
+// Initialize Firecrawl with API key if available, otherwise use local
+const isLocal = !process.env.FIRECRAWL_KEY || process.env.FIRECRAWL_KEY === "your_firecrawl_key";
 const firecrawl = new FirecrawlApp({
-  apiKey: process.env.FIRECRAWL_KEY!,
+  apiKey: isLocal ? 'local-development-token' : process.env.FIRECRAWL_KEY!,
+  apiUrl: isLocal ? (process.env.FIRECRAWL_BASE_URL || 'http://localhost:3002') : undefined
 });
+
+// Default options for API consistency
+const defaultOptions = {
+  search: {
+    timeout: 15000,
+    scrapeOptions: { formats: ['markdown'] }
+  },
+  extract: {
+    timeout: 60000,
+    waitForResults: true
+  },
+  scrape: {
+    timeout: 30000,
+    format: 'markdown'
+  }
+};
 
 // take in user query, return a list of SERP queries
 async function generateSerpQueries({
@@ -156,6 +175,7 @@ export async function deepResearch({
       limit(async () => {
         try {
           const result = await firecrawl.search(serpQuery.query, {
+            ...defaultOptions.search,
             timeout: 15000,
             scrapeOptions: { formats: ['markdown'] },
           });

--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -15,11 +15,11 @@ type ResearchResult = {
 // increase this if you have higher API rate limits
 const ConcurrencyLimit = 2;
 
-// Initialize Firecrawl with API key if available, otherwise use local
-const isLocal = !process.env.FIRECRAWL_KEY || process.env.FIRECRAWL_KEY === "your_firecrawl_key";
+// Initialize Firecrawl with optional API key and optional base url
+
 const firecrawl = new FirecrawlApp({
-  apiKey: isLocal ? 'local-development-token' : process.env.FIRECRAWL_KEY!,
-  apiUrl: isLocal ? (process.env.FIRECRAWL_BASE_URL || 'http://localhost:3002') : undefined
+  apiKey: process.env.FIRECRAWL_KEY ?? "",
+  apiUrl: process.env.FIRECRAWL_BASE_URL 
 });
 
 // Default options for API consistency


### PR DESCRIPTION
# Overview:
Added support for self-hosted Firecrawl

## Changes Made:
- Added local Firecrawl Base Url
- Added extra environment variable to support

## Reason for Change:
- Gives users the ability to use locally hosted Firecrawl.
- Gives users the ability to use Firecrawl on their cloud hosted infrastructure.

## Test Cases Covered:
- [x] Tested with the actual Firecrawl service
- [x] Tested with local instance of Firecrawl
- [ ] Tested with self-hosted remote Firecrawl