### PR TITLE
Add support for requesty.ai as API router

### DIFF
--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -4,23 +4,63 @@ import { getEncoding } from 'js-tiktoken';
 import { RecursiveCharacterTextSplitter } from './text-splitter';
 
 // Providers
+const hasOpenAIKey = !!process.env.OPENAI_KEY;
+const hasRequestyKey = !!process.env.REQUESTY_API_KEY;
 
-const openai = createOpenAI({
-  apiKey: process.env.OPENAI_KEY!,
-});
+if (!hasOpenAIKey && !hasRequestyKey) {
+  throw new Error('No API keys found. Please provide either OPENAI_KEY or REQUESTY_API_KEY in your environment variables.');
+}
 
-// Models
+// Initialize providers based on available keys
+const openai = hasOpenAIKey ? createOpenAI({
+  apiKey: process.env.OPENAI_KEY,
+}) : null;
 
-export const gpt4Model = openai('gpt-4o', {
+const requesty = hasRequestyKey ? createOpenAI({
+  apiKey: process.env.REQUESTY_API_KEY,
+  baseURL: 'https://router.requesty.ai/v1',
+}) : null;
+
+// Get the active provider
+const activeProvider = openai || requesty;
+if (!activeProvider) {
+  throw new Error('No active provider found. This should never happen due to the previous check.');
+}
+
+// Create and export base models using the active provider
+export const gpt4Model = activeProvider(hasOpenAIKey ? 'gpt-4o' : 'openai/gpt-4o', {
   structuredOutputs: true,
 });
-export const gpt4MiniModel = openai('gpt-4o-mini', {
+
+export const gpt4MiniModel = activeProvider('gpt-4o-mini', {
   structuredOutputs: true,
 });
-export const o3MiniModel = openai('o3-mini', {
-  reasoningEffort: 'medium',
+
+export const o3MiniModel = activeProvider(hasOpenAIKey ? 'o3-mini' : 'cline/o3-mini:medium', {
+  ...(hasOpenAIKey ? { reasoningEffort: 'medium' } : {}),
   structuredOutputs: true,
 });
+
+// Create Requesty-specific models if both providers are available
+let requestyGPT4Model;
+let requestyGPT4MiniModel;
+let requestyO3MiniModel;
+
+if (hasRequestyKey && hasOpenAIKey && requesty) {
+  requestyGPT4Model = requesty('openai/gpt-4o', {
+    structuredOutputs: true,
+  });
+
+  requestyGPT4MiniModel = requesty('openai/gpt-4o-mini', {
+    structuredOutputs: true,
+  });
+
+  requestyO3MiniModel = requesty('cline/o3-mini:medium', {
+    structuredOutputs: true,
+  });
+}
+
+export { requestyGPT4Model, requestyGPT4MiniModel, requestyO3MiniModel };
 
 const MinChunkSize = 140;
 const encoder = getEncoding('o200k_base');


### PR DESCRIPTION
I also wanted to add openrouter bus you still need to provide your own Tier3 OpenApi key. Which a lot of people do not have. Requesty.ai does have the ability to provide o3mini and also to specify the reasoning level. 
You probably want to change the code structure / syntax that it alligns more to your standards otherwise i would say pull this one in ;)