### PR TITLE
Expand instructions for local LLM integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ FIRECRAWL_KEY="your_firecrawl_key"
 OPENAI_KEY="your_openai_key"
 ```
 
+To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOINT` and `OPENAI_MODEL`:
+- Set `OPENAI_ENDPOINT` to the address of your local server (eg."http://localhost:1234/v1")
+- Set `OPENAI_MODEL` to the name of the model loaded in your local server.
+
 ### Docker
 
 1. Clone the repository


### PR DESCRIPTION
Adds instructions to setup section for configuring to use LM Studio or other local LLMs that provide an OpenAI-compatible API. Addresses #8 about LM Studio compatibility.