### PR TITLE
Update output file location and Docker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The system will then:
 3. Recursively explore deeper based on findings
 4. Generate a comprehensive markdown report
 
-The final report will be saved as `output.md` in your working directory.
+**Note:** The final report will be saved in the mapped output folder at `output/output.md`.
 
 ### Concurrency
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,5 @@ services:
       - .env.local
     tty: true
     stdin_open: true
+    volumes:
+      - ./output:/app/output

--- a/src/run.ts
+++ b/src/run.ts
@@ -83,10 +83,10 @@ ${followUpQuestions.map((q, i) => `Q: ${q}\nA: ${answers[i]}`).join('\n')}
   });
 
   // Save report to file
-  await fs.writeFile('output.md', report, 'utf-8');
+  await fs.writeFile('output/output.md', report, 'utf-8');
 
   console.log(`\n\nFinal Report:\n\n${report}`);
-  console.log('\nReport has been saved to output.md');
+  console.log('\nReport has been saved to output/output.md');
   rl.close();
 }
 


### PR DESCRIPTION
The output.md file generated from deep research using Docker Compose is deleted when the container stops. Mounting the output folder ensures that the file persists and can be retrieved properly.