### PR TITLE
Sync default depth&breadth in README with code

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ npm start
 You'll be prompted to:
 
 1. Enter your research query
-2. Specify research breadth (recommended: 3-10, default: 6)
-3. Specify research depth (recommended: 1-5, default: 3)
+2. Specify research breadth (recommended: 3-10, default: 4)
+3. Specify research depth (recommended: 1-5, default: 2)
 4. Answer follow-up questions to refine the research direction
 
 The system will then:


### PR DESCRIPTION
Default depth and breadth were decreased in a9ae245, but the README stayed the same.
https://github.com/dzhng/deep-research/blob/2ef450a43cc5857578fdbaecc4048e856fefbcce/src/run.ts#L26-L38
(Curious why the change in defaults BTW)
