### PR TITLE
Optimize Docker caching by reordering COPY and npm install steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM node:18-alpine
 
 WORKDIR /app
 
-COPY . .
-COPY package.json ./
-COPY .env.local ./.env.local
+COPY package.json package-lock.json ./
 
 RUN npm install
+
+COPY . .
+
+COPY .env.local ./.env.local
 
 CMD ["npm", "run", "docker"]


### PR DESCRIPTION
Changes Made:

    Reordered COPY commands to copy package.json and package-lock.json first.
    Moved npm install before copying the rest of the files to leverage Docker's layer caching.
    Ensured that dependencies are only reinstalled when package.json changes and not for every minor change
    in the repo, reducing build times.

Why This Change?

  Previously, any change in the source code would trigger npm install, even if dependencies remained the same. 
  This optimization  ensures that dependencies are only reinstalled when necessary, 
  improving Docker build efficiency specially as the project scales and accumulates more dependencies.