### PR TITLE
docker and readme tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,17 @@ To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOIN
 1. Clone the repository
 2. Rename `.env.example` to `.env.local` and set your API keys
 
-3. Run the Docker image:
+3. Run `npm install`
+
+4. Run the Docker image:
 
 ```bash
-docker compose run --rm deep-research
+docker compose up -d
+```
+
+5. Execute `npm run docker` in the docker service:
+```bash
+docker exec -it deep-research npm run docker
 ```
 
 ## Usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 services:
   deep-research:
+    container_name: deep-research
     build: .
     env_file:
       - .env.local
+    volumes:
+      -  ./:/app/
     tty: true
     stdin_open: true

--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -13,7 +13,7 @@ const openai = createOpenAI({
   baseURL: process.env.OPENAI_ENDPOINT || 'https://api.openai.com/v1',
 } as CustomOpenAIProviderSettings);
 
-const customModel = process.env.OPENAI_MODEL || 'o3-mini';
+const customModel = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 
 // Models
 


### PR DESCRIPTION
Resubmitting this because my original PR introduced unnecessary changes that broke running deep-research on the host machine. The docker compose service was already mostly working, just tweaked the `docker-compose.yml` so that the `output.md` gets placed in the root directory as if it were running on the host machine. Also tweaked the README to make running the docker service a little more clearer. 