### PR TITLE
Added option to research in a different language than English

### DIFF
--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -100,7 +100,7 @@ async function processSerpResult({
   const contents = compact(result.data.map(item => item.markdown)).map(
     content => trimPrompt(content, 25_000),
   );
-  log(`Ran ${query}, found ${contents.length} contents`);
+  log(`Ran "${query}", found ${contents.length} contents`);
 
   const res = await generateObject({
     model: o3MiniModel,
@@ -132,10 +132,12 @@ export async function writeFinalReport({
   prompt,
   learnings,
   visitedUrls,
+  language = 'English',
 }: {
   prompt: string;
   learnings: string[];
   visitedUrls: string[];
+  language: string;
 }) {
   const learningsString = trimPrompt(
     learnings
@@ -147,11 +149,13 @@ export async function writeFinalReport({
   const res = await generateObject({
     model: o3MiniModel,
     system: systemPrompt(),
-    prompt: `Given the following prompt from the user, write a final report on the topic using the learnings from research. Make it as as detailed as possible, aim for 3 or more pages, include ALL the learnings from research:\n\n<prompt>${prompt}</prompt>\n\nHere are all the learnings from previous research:\n\n<learnings>\n${learningsString}\n</learnings>`,
+    prompt: `Given the following prompt from the user, write a final report on the topic using the learnings from research. Make it as detailed as possible, aim for 3 or more pages, include ALL the learnings from research. The report should be written in ${language}:\n\n<prompt>${prompt}</prompt>\n\nHere are all the learnings from previous research:\n\n<learnings>\n${learningsString}\n</learnings>`,
     schema: z.object({
       reportMarkdown: z
         .string()
-        .describe('Final report on the topic in Markdown'),
+        .describe(
+          `Final report on the topic in Markdown, written in ${language}`,
+        ),
     }),
   });
 

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -7,14 +7,16 @@ import { systemPrompt } from './prompt';
 export async function generateFeedback({
   query,
   numQuestions = 3,
+  researchLanguage,
 }: {
   query: string;
   numQuestions?: number;
+  researchLanguage: string;
 }) {
   const userFeedback = await generateObject({
     model: o3MiniModel,
     system: systemPrompt(),
-    prompt: `Given the following query from the user, ask some follow up questions to clarify the research direction. Return a maximum of ${numQuestions} questions, but feel free to return less if the original query is clear: <query>${query}</query>`,
+    prompt: `Given the following query from the user, ask some follow up questions to clarify the research direction. The questions should be in ${researchLanguage}. Return a maximum of ${numQuestions} questions, but feel free to return less if the original query is clear: <query>${query}</query>`,
     schema: z.object({
       questions: z
         .array(z.string())

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -16,7 +16,13 @@ export async function generateFeedback({
   const userFeedback = await generateObject({
     model: o3MiniModel,
     system: systemPrompt(),
-    prompt: `Given the following query from the user, ask some follow up questions to clarify the research direction. The questions should be in ${researchLanguage}. Return a maximum of ${numQuestions} questions, but feel free to return less if the original query is clear: <query>${query}</query>`,
+    prompt: `
+      Given the following query from the user, ask some follow up questions to clarify the research direction.
+      The questions should be in ${researchLanguage}.
+      Return a maximum of ${numQuestions} questions, but feel free to return less if the original query is clear:
+
+      <query>${query}</query>
+    `,
     schema: z.object({
       questions: z
         .array(z.string())

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,10 +31,15 @@ async function run() {
   // Get initial query
   const initialQuery = await askQuestion('What would you like to research? ');
 
-  // Get language preference
+  // Get language preferences
+  const researchLanguage =
+    (await askQuestion(
+      'What language should the research be conducted in? (default: English) ',
+    )) || 'English';
+
   const outputLanguage =
     (await askQuestion(
-      'What language should the report be in? (default: English) ',
+      'What language should the final report be in? (default: English) ',
     )) || 'English';
 
   // Get breath and depth parameters
@@ -56,6 +61,7 @@ async function run() {
   // Generate follow-up questions
   const followUpQuestions = await generateFeedback({
     query: initialQuery,
+    researchLanguage,
   });
 
   log(
@@ -84,7 +90,8 @@ ${followUpQuestions.map((q: string, i: number) => `Q: ${q}\nA: ${answers[i]}`).j
     query: combinedQuery,
     breadth,
     depth,
-    onProgress: (progress) => {
+    researchLanguage,
+    onProgress: progress => {
       output.updateProgress(progress);
     },
   });

--- a/src/run.ts
+++ b/src/run.ts
@@ -31,6 +31,12 @@ async function run() {
   // Get initial query
   const initialQuery = await askQuestion('What would you like to research? ');
 
+  // Get language preference
+  const outputLanguage =
+    (await askQuestion(
+      'What language should the report be in? (default: English) ',
+    )) || 'English';
+
   // Get breath and depth parameters
   const breadth =
     parseInt(
@@ -93,6 +99,7 @@ ${followUpQuestions.map((q: string, i: number) => `Q: ${q}\nA: ${answers[i]}`).j
     prompt: combinedQuery,
     learnings,
     visitedUrls,
+    language: outputLanguage,
   });
 
   // Save report to file


### PR DESCRIPTION
I had to research a topic in a language other than English, so I forked the repository and added language support.
Then I realized there is a difference between research language and (aka the language used for SERP query creation) and report language - you might still want to research in English, while getting your report in a different language.

I changed the run script to ask user for both research- and report-language, with English as default.