### PR TITLE
Exclude o1-mini model from reasoningEffort parameter

### DIFF
--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -18,7 +18,7 @@ const customModel = process.env.OPENAI_MODEL || 'o3-mini';
 // Models
 
 export const o3MiniModel = openai(customModel, {
-  reasoningEffort: customModel.startsWith('o') ? 'medium' : undefined,
+  reasoningEffort: (customModel.startsWith('o') && !customModel.startsWith('o1-mini')) ? 'medium' : undefined,
   structuredOutputs: true,
 });
 


### PR DESCRIPTION
Hi @dzhng,

The `reasoning_effort` parameter is only available for the `o1` and `o3-mini` models (see https://platform.openai.com/docs/api-reference/chat/create#chat-create-reasoning_effort). In this PR I have excluded `o1-mini` model to fix https://github.com/dzhng/deep-research/issues/23 when using `o1-mini`.