### PR TITLE
feat(crawler): add support for Crawl4AI as alternative to Firecrawl

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,20 @@
+# Uncomment the crawler you are using:
+CRAWLER="FIRECRAWL"
+# CRAWLER="CRAWL4AI"
+
+# FIRECRAWL SETTINGS
+# If you are using Firecrawl, add the following below:
 FIRECRAWL_KEY="YOUR_KEY"
 # If you want to use your self-hosted Firecrawl, add the following below:
 # FIRECRAWL_BASE_URL="http://localhost:3002"
 
+# CRAWL4AI SETTINGS
+# If you are using Crawl4AI, add the following below:
+CRAWL4AI_API_TOKEN="YOUR_API_TOKEN"
+# If you your Crawl4AI is running on a different host, add the following below:
+# CRAWL4AI_BASE_URL="http://localhost:11235"
+
+# If you are using OpenAI, add the following below:
 OPENAI_KEY="YOUR_KEY"
 CONTEXT_SIZE="128000"
 # If you want to use other OpenAI compatible API, add the following below:

--- a/README.md
+++ b/README.md
@@ -88,22 +88,23 @@ flowchart TB
 1. Clone the repository
 2. Install dependencies:
 
-```bash
-npm install
-```
+   ```bash
+   npm install
+   ```
 
 3. Set up environment variables in a `.env.local` file:
 
-```bash
-FIRECRAWL_KEY="your_firecrawl_key"
-# If you want to use your self-hosted Firecrawl, add the following below:
-# FIRECRAWL_BASE_URL="http://localhost:3002"
+   ```bash
+   FIRECRAWL_KEY="your_firecrawl_key"
+   # If you want to use your self-hosted Firecrawl, add the following below:
+   # FIRECRAWL_BASE_URL="http://localhost:3002"
 
-OPENAI_KEY="your_openai_key"
-```
+   OPENAI_KEY="your_openai_key"
+   ```
 
 To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOINT` and `OPENAI_MODEL`:
-- Set `OPENAI_ENDPOINT` to the address of your local server (eg."http://localhost:1234/v1")
+
+- Set `OPENAI_ENDPOINT` to the address of your local server (eg."`http://localhost:1234/v1`")
 - Set `OPENAI_MODEL` to the name of the model loaded in your local server.
 
 ### Docker
@@ -115,22 +116,23 @@ To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOIN
 
 4. Run the Docker image:
 
-```bash
-docker compose up -d
-```
+   ```bash
+   docker compose up -d
+   ```
 
 5. Execute `npm run docker` in the docker service:
-```bash
-docker exec -it deep-research npm run docker
-```
+
+   ```bash
+   docker exec -it deep-research npm run docker
+   ```
 
 ## Usage
 
 Run the research assistant:
 
-```bash
-npm start
-```
+   ```bash
+   npm start
+   ```
 
 You'll be prompted to:
 
@@ -158,10 +160,10 @@ If you have a free version, you may sometimes run into rate limit errors, you ca
 
 There are 2 other optional env vars that lets you tweak the endpoint (for other OpenAI compatible APIs like OpenRouter or Gemini) as well as the model string.
 
-```bash
-OPENAI_ENDPOINT="custom_endpoint"
-OPENAI_MODEL="custom_model"
-```
+   ```bash
+   OPENAI_ENDPOINT="custom_endpoint"
+   OPENAI_MODEL="custom_model"
+   ```
 
 ## How It Works
 


### PR DESCRIPTION
This commit introduces a dynamic crawler selection system, allowing the deep research agent to use either [Firecrawl](https://www.firecrawl.dev/) or [Crawl4AI](https://crawl4ai.com/) as its web crawling backend. The changes maintain the existing functionality while adding flexibility in crawler choice.

Key Changes:
- Remove static Firecrawl import and instance creation
- Implement dynamic crawler selection based on CRAWLER environment variable
- Add HTTP API integration for Crawl4AI with proper authentication and polling
- Update environment variable handling for both crawlers
- Standardize response format between both crawlers

Technical Details:
- Add new environment variables:
  * CRAWLER: Toggle between "FIRECRAWL" and "CRAWL4AI"
  * CRAWL4AI_API_TOKEN: Authentication token for Crawl4AI
  * CRAWL4AI_BASE_URL: Optional custom endpoint (default: localhost:11235)
- Implement polling mechanism for Crawl4AI's asynchronous API
- Transform Crawl4AI responses to match Firecrawl's data structure
- Add proper error handling and timeout management for HTTP requests
- Update .env.example with comprehensive documentation

The implementation ensures that the deep research functionality remains unchanged while providing users the flexibility to choose their preferred crawler backend. Error handling and timeout mechanisms have been carefully considered to maintain robustness regardless of the chosen crawler.