### PR TITLE
enhance:generate with pre summary using online content

### DIFF
--- a/src/deep-research.ts
+++ b/src/deep-research.ts
@@ -31,7 +31,7 @@ const ConcurrencyLimit = 2;
 
 // Initialize Firecrawl with optional API key and optional base url
 
-const firecrawl = new FirecrawlApp({
+export const firecrawl = new FirecrawlApp({
   apiKey: process.env.FIRECRAWL_KEY ?? '',
   apiUrl: process.env.FIRECRAWL_BASE_URL,
 });

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,6 +8,7 @@ import {
   writeFinalReport,
 } from './deep-research';
 import { generateFeedback } from './feedback';
+import { generateTopic, generateSummary } from './topic';
 
 // Helper function for consistent logging
 function log(...args: any[]) {
@@ -79,6 +80,22 @@ Initial Query: ${initialQuery}
 Follow-up Questions and Answers:
 ${followUpQuestions.map((q: string, i: number) => `Q: ${q}\nA: ${answers[i]}`).join('\n')}
 `;
+
+  // generate topic for research
+  const researchTopic = await generateTopic({
+    combinedQuery: combinedQuery
+  })
+
+  // generate online content summary for research
+  const summary = await generateSummary({
+    topic: researchTopic
+  })
+
+  combinedQuery = `
+  Topic: ${researchTopic}
+  Summary: ${summary}
+  ${combinedQuery}
+  `
   }
 
   log('\nStarting research...\n');

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -1,0 +1,53 @@
+import { generateObject } from 'ai';
+import { z } from 'zod';
+
+import { getModel, trimPrompt } from './ai/providers';
+import { systemPrompt } from './prompt';
+import { firecrawl } from './deep-research'
+import { compact } from 'lodash-es';
+
+export async function generateTopic({
+    combinedQuery,
+  }: {
+    combinedQuery: string;
+  }) {
+    const topic = await generateObject({
+      model: getModel(),
+      system: systemPrompt(),
+      prompt: `Given the following prompt from the user, generate a researchable and professional topic. <prompt>${combinedQuery}</prompt>`,
+      schema: z.object({
+        topic: z
+          .string()
+          .describe('research topic for user'),
+      }),
+    });
+    return topic.object.topic
+  }
+
+  export async function generateSummary({
+    topic,
+  }: {
+    topic: string;
+  }) {
+    const result = await firecrawl.search(topic, {
+    timeout: 15000,
+    limit: 5,
+    scrapeOptions: { formats: ['markdown'] },
+    });
+
+    const contents = compact(result.data.map(item => item.markdown)).map(
+    content => trimPrompt(content, 25_000),
+    );
+
+    const summary = await generateObject({
+      model: getModel(),
+      system: systemPrompt(),
+      prompt: `Given the following prompt from the user, generate a summary about this topic from content. <topic>${topic}</topic><content>${contents.join('\n')}</content>`,
+      schema: z.object({
+        summary: z
+          .string()
+          .describe('research summary'),
+      }),
+    });
+    return summary.object.summary
+  }


### PR DESCRIPTION
# Generate with pre summary using online content

## Overview
This PR will generate a research topic  using user original query feedback queries, and answers.This topic will be searched by firecrawl before we go into deepresearch and generate a summary from the real time internal content. When go into deep research, topic and summary will attach to combinedQuery.

## Why we need pre summary
- Model are pre trained, which means they don't have real time informations. If a user generate a report about recent hot events, model is probably missing some informations.
- With more real time informations, I believe deep research can generate a better report, and the result turns out as i expected. See files following:
[report_with_pre_summary.md](https://github.com/user-attachments/files/19150690/report_with_pre_summary.md)
[report_without_pre_summary.md](https://github.com/user-attachments/files/19150691/report_without_pre_summary.md)

## inputs
Using model:  o3-mini
What would you like to research? what can i do with manus(an AI agent published a few days before)?
Enter research breadth (recommended 2-10, default 4): 4
Enter research depth (recommended 1-5, default 2): 2
Do you want to generate a long report or a specific answer? (report/answer, default report): report
Could you specify what you mean by 'what can I do with manus'? Are you interested in its technical features, integration capabilities, application-specific use cases, or something else?
Your answer: all above
Are you looking to use manus for a particular industry or research domain, and if so, which one?
Your answer: all above
Do you want insights into how to customize or extend manus for your needs, or are you more focused on understanding its core functionalities?
Your answer: all above
