### PR TITLE
Fix docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOIN
 1. Clone the repository
 2. Rename `.env.example` to `.env.local` and set your API keys
 
-3. Run `npm install`
+3. Run `docker build -f Dockerfile`
 
 4. Run the Docker image:
 


### PR DESCRIPTION
The docker instruction mistakenly references `npm install` instead of `docker build`

Closes #110.

Though I'm not sure about the need of docker compose afterward, just running the docker image should be fine as it internally calls `npm run docker` already.