### PR TITLE
Fix Docker build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ To use local LLM, comment out `OPENAI_KEY` and instead uncomment `OPENAI_ENDPOIN
 1. Clone the repository
 2. Rename `.env.example` to `.env.local` and set your API keys
 
-3. Run `docker build -f Dockerfile`
+3. Run `docker build -f Dockerfile .`
 
 4. Run the Docker image:
 


### PR DESCRIPTION
 Include the current directory (.) in the build context.