### PR TITLE
Update providers.ts to work with local OPENAI providers

### DIFF
--- a/src/ai/providers.ts
+++ b/src/ai/providers.ts
@@ -10,12 +10,10 @@ import { getEncoding } from 'js-tiktoken';
 import { RecursiveCharacterTextSplitter } from './text-splitter';
 
 // Providers
-const openai = process.env.OPENAI_KEY
-  ? createOpenAI({
+const openai = createOpenAI({
       apiKey: process.env.OPENAI_KEY,
       baseURL: process.env.OPENAI_ENDPOINT || 'https://api.openai.com/v1',
-    })
-  : undefined;
+    });
 
 const fireworks = process.env.FIREWORKS_KEY
   ? createFireworks({


### PR DESCRIPTION
Made this provider code compatible with the README instructions.  Quote README: "To use local LLM, comment out OPENAI_KEY and instead uncomment OPENAI_ENDPOINT and OPENAI_MODEL" The previous version would not work if user leaves the OPEN_AI key empty `OPENAI_KEY=""` and attempts to use a local model (e.g., coming from LMStudio)